### PR TITLE
Added new register class for zeropage locations, improved petscii conversion

### DIFF
--- a/gcc/config/6502/6502.c
+++ b/gcc/config/6502/6502.c
@@ -999,15 +999,15 @@ m65x_output_ascii (FILE *f, const char *str, int len)
 	  switch (state)
 	    {
 	    case START:
-	      fprintf (f, "\t.byte $%x", str[i]);
+	      fprintf (f, "\t.byte $%x", (unsigned char)str[i]);
 	      break;
 	    
 	    case PRINT:
-	      fprintf (f, "\", $%x", str[i]);
+	      fprintf (f, "\", $%x", (unsigned char)str[i]);
 	      break;
 
 	    case NONPRINT:
-	      fprintf (f, ", $%x", str[i]);
+	      fprintf (f, ", $%x", (unsigned char)str[i]);
 	    }
 	  state = NONPRINT;
 	}

--- a/gcc/config/6502/constraints.md
+++ b/gcc/config/6502/constraints.md
@@ -18,6 +18,8 @@
 ;(define_register_constraint "hh" "WORD_HARD_REGS")
 ;(define_register_constraint "hs" "HARD_REGS")
 
+(define_register_constraint "Zp" "HARD_ZP_REGS")
+
 (define_constraint "I"
   "An integer 0-255."
   (and (match_code "const_int")

--- a/libcpp/charset.c
+++ b/libcpp/charset.c
@@ -474,11 +474,15 @@ one_utf8_to_petscii (iconv_t bigend, const uchar **inbufp, size_t *inbytesleftp,
       return E2BIG;
     }
 
-  /* Swap small and capital chars.  */
+  /* Swap lower case and higher case chars.  */
   if (s >= 65 && s <= 90)  
     s += 32;  
   else if (s >= 97 && s <= 122)  
     s -= 32;  
+
+  /* Convert newline to return */
+  if (s == 10)
+    s = 13;
 
   outbuf[0] = s;
 

--- a/libcpp/charset.c
+++ b/libcpp/charset.c
@@ -446,6 +446,47 @@ one_utf16_to_utf8 (iconv_t bigend, const uchar **inbufp, size_t *inbytesleftp,
   return 0;
 }
 
+static inline int
+one_utf8_to_petscii (iconv_t bigend, const uchar **inbufp, size_t *inbytesleftp,
+		     uchar **outbufp, size_t *outbytesleftp)
+{
+  int rval;
+  cppchar_t s = 0;
+  const uchar *save_inbuf = *inbufp;
+  size_t save_inbytesleft = *inbytesleftp;
+  uchar *outbuf = *outbufp;
+
+  rval = one_utf8_to_cppchar (inbufp, inbytesleftp, &s);
+  if (rval)
+    return rval;
+
+  if (s > 0x80)
+    {
+      *inbufp = save_inbuf;
+      *inbytesleftp = save_inbytesleft;
+      return EILSEQ;
+    }
+
+  if (*outbytesleftp < 1)
+    {
+    *inbufp = save_inbuf;
+    *inbytesleftp = save_inbytesleft;
+    return E2BIG;
+    }
+
+  /* swap small and capital chars */
+  if (s >= 65 && s <= 90)  
+    s += 32;  
+  else if (s >= 97 && s <= 122)  
+    s -= 32;  
+
+  outbuf[0] = s;
+
+  *outbufp += 1;
+  *outbytesleftp -= 1;
+  return 0;
+}
+
 /* Helper routine for the next few functions.  The 'const' on
    one_conversion means that we promise not to modify what function is
    pointed to, which lets the inliner see through it.  */
@@ -513,6 +554,13 @@ convert_utf8_utf32 (iconv_t cd, const uchar *from, size_t flen,
 		    struct _cpp_strbuf *to)
 {
   return conversion_loop (one_utf8_to_utf32, cd, from, flen, to);
+}
+
+static bool
+convert_utf8_petscii (iconv_t cd, const uchar *from, size_t flen,
+		      struct _cpp_strbuf *to)
+{
+  return conversion_loop (one_utf8_to_petscii, cd, from, flen, to);
 }
 
 static bool
@@ -620,6 +668,7 @@ static const struct cpp_conversion conversion_tab[] = {
   { "UTF-8/UTF-32BE", convert_utf8_utf32, (iconv_t)1 },
   { "UTF-8/UTF-16LE", convert_utf8_utf16, (iconv_t)0 },
   { "UTF-8/UTF-16BE", convert_utf8_utf16, (iconv_t)1 },
+  { "UTF-8/PETSCII" , convert_utf8_petscii, (iconv_t)0 },
   { "UTF-32LE/UTF-8", convert_utf32_utf8, (iconv_t)0 },
   { "UTF-32BE/UTF-8", convert_utf32_utf8, (iconv_t)1 },
   { "UTF-16LE/UTF-8", convert_utf16_utf8, (iconv_t)0 },

--- a/libgcc/config/6502/crt0.S
+++ b/libgcc/config/6502/crt0.S
@@ -27,6 +27,8 @@ line2:
 #endif
 
 	.segment "STARTUP"
+	lda #38
+	sta 1
 	lda #<__STACKTOP__
 	sta _sp0
 	lda #>__STACKTOP__
@@ -70,8 +72,13 @@ nobss:
 #ifdef __SEMI65X__
 	; This is a special hack to exit the semi65x emulator.
 	jmp 0
-#elif defined(__BBCMICRO__) || defined(__C64__)
+#elif defined(__BBCMICRO__)
 	; Return to caller
+	rts
+#elif defined(__C64__)
+	; turn on BASIC ROM again
+	lda #$27
+	sta 1
 	rts
 #else
 #error "Don't know how to exit on this machine"


### PR DESCRIPTION
I hope I did this right: I think we need a register class for zeropage locations, so that the compiler can chose addresses freely. 
